### PR TITLE
Add infura.io RPC endpoints to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ __POA Network is NOT an ERC20 token, but is ERC20 Compatiable. POA has its own b
 ### Core (live)
 
 - Core (live) RPC endpoint: `https://core.poa.network`
+- Core (live) RPC infura.io endpoint: `https://poa.infura.io`
+- Core (live) RPC infura.io WebSocket endpoint: `wss://poa.infura.io/ws`
 - Core (live) Netstats: [https://core-netstat.poa.network/](https://core-netstat.poa.network/)
 
 ### Sokol (test)


### PR DESCRIPTION
The suggestion is to add the next infura.io RPC endpoints to README:
- `https://poa.infura.io`
- `wss://poa.infura.io/ws`